### PR TITLE
Use 16-digit project hash for preview passwords

### DIFF
--- a/src/main/java/com/armikom/zen/service/PreviewService.java
+++ b/src/main/java/com/armikom/zen/service/PreviewService.java
@@ -7,11 +7,13 @@ import org.slf4j.LoggerFactory;
 
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.tomcat.util.http.fileupload.FileUtils;
 
@@ -150,7 +152,9 @@ public class PreviewService {
     }
 
     private String generatePassword(String projectId) {
-        return "MyZen25!"+projectId;
+        UUID uuid = UUID.nameUUIDFromBytes(projectId.getBytes(StandardCharsets.UTF_8));
+        String hashedId = String.format("%016x", uuid.getMostSignificantBits());
+        return "MyZen25!" + hashedId;
     }
 
     /**

--- a/test-database-service.http
+++ b/test-database-service.http
@@ -6,7 +6,7 @@
 @baseUrl = http://localhost:8080/api/database
 @testDbName = testdb_demo
 @testUsername = testuser
-@testPassword = MyZen25!tour-buddy
+@testPassword = MyZen25!17044b79e9bf3fe4
 @backupPath = /tmp/backup_testdb.sql
 
 ###


### PR DESCRIPTION
## Summary
- Derive preview database password from 16-digit hex hash of project ID
- Update HTTP API test sample to reflect longer hashed password

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_b_68a1a1c89eb48333acc0a51a630ac78c