### PR TITLE
feat: add mssql express setup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,6 +3,10 @@ services:
     image: myzen/backend:3
     ports:
       - 8080:8080
-
+      - 1433:1433
     env_file:
       - .env
+    environment:
+      - MSSQL_SA_PASSWORD=YourStrong!Passw0rd
+      - ACCEPT_EULA=Y
+


### PR DESCRIPTION
## Summary
- add Microsoft SQL Server Express installation to Dockerfile and run alongside app
- expose 1433 and configure SQL Server in docker-compose

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_b_68a8ac6df3508333ab42218d2e50b1f2